### PR TITLE
Update document after 2015-10-05 meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,47 @@
 # nyudl-mdi-guidelines
-
-
+#### *Version: 0.1.0-alpha*
 ## Overview
 This repo contains guidelines, best practices, and patterns as we
 learn more about developing with, deploying, running, and monitoring a
-Message Driven Infrastructure (MDI).
+Message Driven Infrastructure (MDI).  We plan to update this repo as we learn.
 
+## Project Guiding Principles
+We want to avoid premature optimization, *slow and correct is better than fast and wrong*.
+We will use iterative development and exercise the full toolchain, e.g.,
+Github + Travis + Jenkins + TBD for monitoring
+
+<br>
 ## Status
 Under Development
 
-## Version
-0.1.0-alpha
-
-## Approach
-* learn
-* question
-* prototype
-* avoid premature optimization
-  * *slow and correct is better than fast and wrong*
-* iterative development
-  * exercise full toolchain
-    * Github + Travis + Jenkins + TBD for monitoring
-
+<br>
 ## Message Attributes
-* persistent
+* `persistent` : all messages must be `persistent`
 
-## Queue Attributes
-* durable
+<br>
+## Queue attributes
+* `durable`: all queues must be `durable`
 
+<br>
+## Exchange Attributes
+* `durable`: the exchange must be `durable`
+
+<br>
 ## Exchange Types in scope
-* topic
+* `topic`: we will use one `topic` exchange for all messages
 
-## Routing Key and Binding Key Template
+<br>
+## Message Routing Key Template
 #### `<service code>.<message type>[.<result code>]`
 
-#### Template Components:
-| Component | Required? | Description |
+#### Routing Key Template Words:
+| Word | Required? | Description |
 |-----------|-----------|-------------|
-| `service code` | YES | A value from the **Service Code Controlled Vocabulary** (see below) |
-| `message type` | YES | A value from the **Message Type Controlled Vocabulary** (see below) |
+| `service code` | YES | A value from the [**Service Code Controlled Vocabulary**](#service-code-controlled-vocabulary) |
+| `message type` | YES | A value from the [**Message Type Controlled Vocabulary**](#message-type-controlled-vocabulary) |
 | `result code` | no | A value from the **Result Code Controlled Vocabulary** (see below) |
 
 
-###### Template Usage Examples
 | Message Routing Key Examples  |
 |-------------------------------|
 |`deriv_gen.request`            |
@@ -59,8 +58,7 @@ Under Development
 | `deriv_gen.request`       | derivative generation worker |
 | `e01verify.request`       | E01 verify worker  |
 
-
-
+<br>
 ## Messaging Pattern
 0. Message Consumer (usually a Service) subscribes to the topic exchange using   
    the appropriate binding key.  
@@ -70,18 +68,45 @@ Under Development
 0. Consumer receives message from queue
 0. Consumer may send out `status` messages during processing, e.g., when a   
    service starts work on a request it may sends a `status` of 'busy'
-0. Consumer performs task
+0. Consumer processes request
 0. Consumer publishes response message to the topic exchange
 0. Consumer `ACK`s request message
 
-## Consumer subscriptions
-* subscribe to **topic** exchange with very selective binding key
-
-## Queue attributes
-* Consumers
+<br>
+## Message Consumer Responsibilities
   * must subscribe to the topic exchange using the correct binding key
-  * prefetch = 1
-  * must send responses to the topic exchange
-  * must `ACK` request messages after work complete
+  * must set `prefetch = 1`
+  * must send `response` messages to the topic exchange
+  * must `ACK` `request` messages after `request` processing is complete
 
+<br>
+## Message Formats
+  * Please refer to the [NYUDL MDI Message](https://github.com/NYULibraries/nyudl-mdi-message) repository for details
+
+<br>
+## Routing Key Controlled Vocabularies
+### Service Code Controlled Vocabulary
+| Service Code | Description | Granularity |
+|--------------|-------------|-------------|
+| e01verify  ***Don, please change if desired***  | ***Don, please fill in*** | ***Don, please fill in*** |
+| deriv_gen  ***Rasan, please change if desired***  | ***Rasan, please fill in*** | ***Rasan, please fill in*** |
+| bag_validation | Check that directory conforms to BagIt specification | bag directory |
+<br>
+
+### Message Type Controlled Vocabulary
+| Message Type | Description |
+|--------------|-------------|
+| `request`    | sent to a service |
+| `response`   | sent in response to `request` |
+| `status`     | used to broadcast the status of a request |
+<br>
+### Result Code Controlled Vocabulary
+| Result Code  | Description |
+|--------------|-------------|
+| `success`    | `request` was processed successfully |
+| `failure`    | `request` failed |  
+<br>
+
+----
+#### ***end of document***
 ----

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a work in progress.
 
 
 ## Version
-0.0.1-alpha
+0.1.0
 
 ## Approach
 * learn
@@ -30,7 +30,6 @@ This is a work in progress.
 * durable
 
 ## Exchange Types in scope
-* direct
 * topic
 
 ## Routing and Binding templates

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Under Development
 <br>
 ## Exchange Attributes
 * `durable`: the exchange must be `durable`
+* `rstar_topic` : the topic exchange name is `rstar_topic`
 
 <br>
 ## Exchange Types in scope

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This is a work in progress.
 #### `key` Components
 | component      | example values |
 |----------------|----------------|
-|`app`           | `rstar` |
 | `service`      | `xip_validation`, `file_identify`, <br>`file_virus_scan`, `file_chz`, <br>`file_video_xcode`...|
 | `message type` | `request`, `result`, `status` |
 
@@ -46,24 +45,24 @@ This is a work in progress.
 ##### `<app>.<service>.<message type>`
 | service             | role     | routing key                   |
 |---------------------|----------|-------------------------------|
-| bag validation      | producer | `rstar.xip_validate.request`  |
-| video transcoding   | producer | `rstar.video_xcode.request`   |
-| file identification | producer | `rstar.file_identify.request` |
+| bag validation      | producer | `xip_validate.request`  |
+| video transcoding   | producer | `video_xcode.request`   |
+| file identification | producer | `file_identify.request` |
 |                     |          |                               |
-| bag validation      | consumer | `rstar.xip_validate.result`   |
-| video transcoding   | consumer | `rstar.video_xcode.result`    |
-| file identification | consumer | `rstar.file_identify.result`  |
+| bag validation      | consumer | `xip_validate.result`   |
+| video transcoding   | consumer | `video_xcode.result`    |
+| file identification | consumer | `file_identify.result`  |
 
 
 #### Binding Key Template
 ##### `<app>.<service>.<message type>`
 | service             | role     | binding key                   |
 |---------------------|----------|-------------------------------|
-| event logger        | consumer | `rstar.*.result`              |
-| jobs database       | consumer | `rstar.#`                     |
-| bag validation      | consumer | `rstar.xip_validate.request`  |
-| video transcoding   | consumer | `rstar.video_xcode.request`   |
-| file identification | consumer | `rstar.file_identify.request` |
+| event logger        | consumer | `*.result`              |
+| jobs database       | consumer | `#`                     |
+| bag validation      | consumer | `xip_validate.request`  |
+| video transcoding   | consumer | `video_xcode.request`   |
+| file identification | consumer | `file_identify.request` |
 
 
 ## Messaging Pattern


### PR DESCRIPTION
Hi @rrasch @dmmd ,

I updated this repo with the outcome of yesterday's meeting.

A few issues:
1.) I added controlled vocabulary to the README.  Please provide comments on what you want your `service code` and `service descriptions` to be and I will update the controlled vocabulary table.

2.) Topic Exchange name. I realized I forgot to ask what name we should use for the Topic Exchange.
Does `rstar_topic` work?  Please let me know.  If not, please propose an alternative.

3.) Don asked whether we need a `response id`.  I've been thinking about using the `request id` as the primary key throughout the system for a request, e.g., to use the jobs database, one would query by the `request id`; the Event Logger would use the `request id` as the `event identifier`. I don't have a specific use case for a `response id`. @dmmd , could you add a comment to this PR with a use case for the `response id`?

4.)  Please add comments if any part of the document is unclear, or if you want to make changes.

Thank you for your time and for meeting yesterday!
Best-
Joe

Cc: @ckassel  
